### PR TITLE
Fix E-Cell visibility and Our Family card rendering fallback

### DIFF
--- a/src/app/clubs/ecell/page.tsx
+++ b/src/app/clubs/ecell/page.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import NewClubPageTemplate from "@/components/NewClubPageTemplate";
+import clubData from "@/data/societies/ecell";
+
+function ECellClub() {
+  return <NewClubPageTemplate {...clubData} />;
+}
+
+export default ECellClub;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,7 @@
 // app/layout.tsx
-import '@fontsource/roboto/300.css';
-import '@fontsource/roboto/400.css';
-import '@fontsource/roboto/500.css';
-import '@fontsource/roboto/700.css';
-import '@fontsource/roboto/800.css';
 import './globals.css'
 
-import { Bricolage_Grotesque } from 'next/font/google';
+import { Bricolage_Grotesque, Roboto } from 'next/font/google';
 import { ThemeProvider } from '@/context/ThemeContext';
 import { ReactLenis } from 'lenis/react';
 import ConditionalShell from '@/components/ConditionalShell';
@@ -22,11 +17,18 @@ const bricolage = Bricolage_Grotesque({
   variable: '--font-bricolage',
 });
 
+const roboto = Roboto({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '700'],
+  display: 'swap',
+  variable: '--font-roboto',
+});
+
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const { user } = await getCurrentSession();
 
   return (
-    <html lang="en" suppressHydrationWarning className={bricolage.variable}>
+    <html lang="en" suppressHydrationWarning className={`${bricolage.variable} ${roboto.variable}`}>
       <head />
       <body>
         <ReactLenis root />

--- a/src/app/open-house/page.tsx
+++ b/src/app/open-house/page.tsx
@@ -107,7 +107,7 @@ const bodies = [
     { name: 'Team Nira', desc: 'Autonomous Underwater Vehicle', logo: '/teams/nira/logo.webp', route: '/teams/nira', cat: 'Teams' },
     { name: 'Team Shunya', desc: 'Mars Rover Systems', logo: '/teams/mars/logo.webp', route: '/teams/shunya', cat: 'Teams' },
     { name: 'CS Club', desc: 'Algorithms, CP & Dev Culture', logo: '/clubs/csclub/logo.webp', route: '/clubs/cs', cat: 'Clubs' },
-    { name: 'E-Cell', desc: 'Startups & Entrepreneurship', logo: '/societies/Ecell/logo.webp', route: '/societies/ecell', cat: 'Societies' },
+    { name: 'E-Cell', desc: 'Startups & Entrepreneurship', logo: '/societies/Ecell/logo.webp', route: '/clubs/ecell', cat: 'Clubs' },
     { name: 'Cybersecurity Club', desc: 'CTFs, Security & Red Teaming', logo: '/clubs/cybersecurity/logo.jpg', route: '/clubs/cybersecurity', cat: 'Clubs' },
     { name: 'Developers Club', desc: 'Full-stack, Open Source & Hackathons', logo: '/clubs/devclub/logo.png', route: '/clubs/dev', cat: 'Clubs' },
     { name: 'Robotics Club', desc: 'Bots, Arms & Automation', logo: '/clubs/robotics/logo.webp', route: '/clubs/robotics', cat: 'Clubs' },

--- a/src/app/societies/ecell/page.tsx
+++ b/src/app/societies/ecell/page.tsx
@@ -1,25 +1,5 @@
-import React from "react";
-import ClubPageTemplate from "@/components/ClubPageTemplate";
-import clubData from "@/data/societies/ecell";
+import { redirect } from "next/navigation";
 
-// ClubPageTemplate (old template) uses `description` instead of `introduction`,
-// and its Project type uses `title` + `icons` instead of `name` + `image`.
-const templateProps = {
-  name: clubData.name,
-  logo: clubData.logo,
-  description: clubData.introduction,
-  core: clubData.core,
-  links: clubData.links,
-  projects: clubData.projects.map((p) => ({
-    title: p.name,
-    description: p.description,
-    themeColor: p.themeColor ?? "#7C3AED",
-    icons: [] as React.ReactElement[],
-  })),
-};
-
-function ECell() {
-  return <ClubPageTemplate {...templateProps} />;
+export default function ECellSocietyRedirect() {
+  redirect("/clubs/ecell");
 }
-
-export default ECell;

--- a/src/data/orgs.ts
+++ b/src/data/orgs.ts
@@ -13,6 +13,7 @@ export const clubs: OrgItem[] = [
   { name: "Developers Club",    image: "/clubs/devclub/logo.png",    link: "/clubs/dev" },
   { name: "Robotics Club",      image: "/clubs/robotics/logo.webp",  link: "/clubs/robotics" },
   { name: "System Coding Club", image: "/clubs/Scc/logo1.webp",      link: "/clubs/scc" },
+  { name: "E-Cell",             image: "/societies/Ecell/logo.webp", link: "/clubs/ecell" },
   { name: "Cybersecurity Club", image: "/clubs/cybersecurity/logo.jpg", link: "/clubs/cybersecurity" },
 ];
 
@@ -25,7 +26,6 @@ export const teams: OrgItem[] = [
 ];
 
 export const societies: OrgItem[] = [
-  { name: "E-Cell",                image: "/societies/Ecell/logo.webp",                    link: "/societies/ecell" },
   { name: "IEEE",                  image: "/societies/IEEE/logo.png",                      link: "/societies/ieee" },
   { name: "Optica Student Chapter",image: "/societies/OpticaStudentChapter/logo.webp",     link: "/societies/optica" },
   { name: "ASME Student Section",  image: "/societies/ASMEStudentSection/logo.webp",       link: "/societies/asme" },

--- a/src/hooks/useOrgs.ts
+++ b/src/hooks/useOrgs.ts
@@ -1,6 +1,12 @@
 "use client";
 
 import { useState, useEffect } from 'react';
+import {
+  clubs as staticClubs,
+  teams as staticTeams,
+  societies as staticSocieties,
+  communities as staticCommunities,
+} from '@/data/orgs';
 
 export interface OrgItem {
   id: number;
@@ -14,13 +20,41 @@ export interface OrgItem {
 let _cache: OrgItem[] | null = null;
 let _promise: Promise<OrgItem[]> | null = null;
 
+function staticFallbackOrgs(): OrgItem[] {
+  let id = 1;
+  const toRows = (category: string, items: Array<{ name: string; image: string; link: string }>) =>
+    items.map((item, index) => ({
+      id: id++,
+      name: item.name,
+      image: item.image,
+      link: item.link,
+      category,
+      sort_order: index,
+    }));
+
+  return [
+    ...toRows('club', staticClubs),
+    ...toRows('team', staticTeams),
+    ...toRows('society', staticSocieties),
+    ...toRows('community', staticCommunities),
+  ];
+}
+
 async function fetchOrgs(): Promise<OrgItem[]> {
-  if (_cache) return _cache;
+  if (_cache && _cache.length > 0) return _cache;
   if (!_promise) {
+    const fallback = staticFallbackOrgs();
     _promise = fetch('/api/orgs')
       .then((r) => (r.ok ? r.json() : []))
-      .then((rows) => { _cache = rows; return rows; })
-      .catch(() => []);
+      .then((rows) => {
+        const safeRows = Array.isArray(rows) ? rows : [];
+        _cache = safeRows.length ? safeRows : fallback;
+        return _cache;
+      })
+      .catch(() => {
+        _cache = fallback;
+        return fallback;
+      });
   }
   return _promise;
 }

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,6 +1,6 @@
 import { createTheme } from '@mui/material/styles';
 
-const fontFamily = "var(--font-bricolage), 'Roboto', system-ui, sans-serif";
+const fontFamily = "var(--font-bricolage), var(--font-roboto), 'Roboto', system-ui, sans-serif";
 
 // ── Institute blue / PCB palette ─────────────────────────────────────────────
 // Primary   : Sky blue           #7dd3fc   (dark-mode trace highlight)


### PR DESCRIPTION
## Summary
- Add `E-Cell` to clubs org listing and route it to `/clubs/ecell`
- Add local club page at `/clubs/ecell` using `NewClubPageTemplate`
- Redirect legacy `/societies/ecell` path to `/clubs/ecell`
- Update Open House card metadata to classify E-Cell under Clubs
- Add robust fallback in `useOrgs` so Team/Family cards render even when `/api/orgs` is empty or unavailable
- Keep typography setup consistent by wiring Roboto through `next/font` variables

## Why
On local setups with empty org DB rows, `useOrgsByCategory` returned empty arrays, causing no cards to appear in "Our Family". Also, E-Cell needed to appear under Clubs consistently across pages.

## Validation
- `npm run lint` (passes with existing `no-img-element` warning in `ProjectCard.tsx`)
- `npm run build` compiles but needs auth env (`GOOGLE_CLIENT_ID`) to complete route data collection

## Notes
- This PR does not change auth behavior; build env requirements remain as-is.